### PR TITLE
Feature/load external zip file from inputstream

### DIFF
--- a/src/main/java/com/blueconic/browscap/UserAgentService.java
+++ b/src/main/java/com/blueconic/browscap/UserAgentService.java
@@ -111,7 +111,7 @@ public class UserAgentService {
                 return new FileInputStream(myZipFilePath);
             }
         } else {
-           return myZipFileStream;
+            return myZipFileStream;
         }
     }
 }

--- a/src/main/java/com/blueconic/browscap/UserAgentService.java
+++ b/src/main/java/com/blueconic/browscap/UserAgentService.java
@@ -24,6 +24,7 @@ public class UserAgentService {
     // The version of the browscap file this bundle depends on
     public static final int BUNDLED_BROWSCAP_VERSION = 6000030;
     private String myZipFilePath;
+    private InputStream myZipFileStream;
 
     public UserAgentService() {
         // Default
@@ -36,6 +37,15 @@ public class UserAgentService {
      */
     public UserAgentService(final String zipFilePath) {
         myZipFilePath = zipFilePath;
+    }
+
+    /**
+     * Creates a user agent service based on the Browscap CSV file in the given ZIP InputStream
+     * @param zipFileStream the zip InputStream should contain the csv file. It will load
+     *            the given zip InputStream instead of the bundled zip file
+     */
+    public UserAgentService(final InputStream zipFileStream) {
+        myZipFileStream = zipFileStream;
     }
 
     /**
@@ -93,11 +103,15 @@ public class UserAgentService {
      * @throws FileNotFoundException
      */
     private InputStream getCsvFileStream() throws FileNotFoundException {
-        if (myZipFilePath == null) {
-            final String csvFileName = getBundledCsvFileName();
-            return getClass().getClassLoader().getResourceAsStream(csvFileName);
+        if (myZipFileStream == null) {
+            if (myZipFilePath == null) {
+                final String csvFileName = getBundledCsvFileName();
+                return getClass().getClassLoader().getResourceAsStream(csvFileName);
+            } else {
+                return new FileInputStream(myZipFilePath);
+            }
         } else {
-            return new FileInputStream(myZipFilePath);
+           return myZipFileStream;
         }
     }
 }

--- a/src/test/java/com/blueconic/browscap/impl/UserAgentServiceTest.java
+++ b/src/test/java/com/blueconic/browscap/impl/UserAgentServiceTest.java
@@ -14,6 +14,7 @@ import static java.util.Arrays.asList;
 import static org.junit.Assert.assertEquals;
 
 import java.io.BufferedReader;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -37,6 +38,23 @@ public class UserAgentServiceTest {
 
         final Path path = Paths.get("src", "main", "resources", UserAgentService.getBundledCsvFileName());
         final UserAgentService uas = new UserAgentService(path.toString());
+
+        final UserAgentParser parser = uas.loadParser();
+
+        int counter = 0;
+        for (int i = 0; i < ITERATIONS; i++) {
+            counter += processUserAgentFile(parser);
+        }
+        System.out.print("Processed " + counter + " items\n");
+    }
+
+    @Test
+    public void testUserAgentsFromExternalInputStream() throws IOException, ParseException {
+        final int ITERATIONS = 10;
+
+        final Path path = Paths.get("src", "main", "resources", UserAgentService.getBundledCsvFileName());
+        final InputStream fileStream = new FileInputStream(path.toString());
+        final UserAgentService uas = new UserAgentService(fileStream);
 
         final UserAgentParser parser = uas.loadParser();
 


### PR DESCRIPTION
Hi,
At my company, we store the browscap file on HDFS.
This patch allows to support this (and other FileSystem datastores) without having to depend on HDFS libs