### PR TITLE
- replaced opencsv by common csv to reduce dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,8 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+/target/
+/.settings/
+/.classpath
+/.project
+/bin/

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.blueconic</groupId>
     <artifactId>browscap-java</artifactId>
     <packaging>jar</packaging>
-    <version>1.2.5</version>
+    <version>1.2.6</version>
     <name>browscap-java</name>
     <description>A blazingly fast and memory efficient Java client on top of the BrowsCap CSV source files.</description>
 
@@ -38,9 +38,9 @@
     </properties>
     <dependencies>
         <dependency>
-            <groupId>com.opencsv</groupId>
-            <artifactId>opencsv</artifactId>
-            <version>4.1</version>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-csv</artifactId>
+          <version>1.6</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
i've replaced opencsv by common-csv to reduce dependencies

[INFO] com.blueconic:browscap-java:jar:1.2.5
[INFO] +- com.opencsv:opencsv:jar:4.1:compile
[INFO] |  +- org.apache.commons:commons-lang3:jar:3.6:compile
[INFO] |  +- org.apache.commons:commons-text:jar:1.1:compile
[INFO] |  \- commons-beanutils:commons-beanutils:jar:1.9.3:compile
[INFO] |     +- commons-logging:commons-logging:jar:1.2:compile
[INFO] |     \- commons-collections:commons-collections:jar:3.2.2:compile
[INFO] \- junit:junit:jar:4.12:test
[INFO]    \- org.hamcrest:hamcrest-core:jar:1.3:test

vs 
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ browscap-java ---
[INFO] com.blueconic:browscap-java:jar:1.2.6
[INFO] +- org.apache.commons:commons-csv:jar:1.6:compile
[INFO] \- junit:junit:jar:4.12:test
[INFO]    \- org.hamcrest:hamcrest-core:jar:1.3:test

