### PR TITLE
Migrate tests to JUnit Jupiter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -43,12 +43,20 @@
             <version>2.9.1</version>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.9.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.2</version>
+            </plugin>
+        </plugins>
+    </build>
     <profiles>
         <profile>
             <id>default</id>

--- a/src/test/java/com/blueconic/browscap/impl/RuleTest.java
+++ b/src/test/java/com/blueconic/browscap/impl/RuleTest.java
@@ -3,24 +3,24 @@ package com.blueconic.browscap.impl;
 import static com.blueconic.browscap.BrowsCapField.BROWSER;
 import static com.blueconic.browscap.impl.UserAgentFileParserTest.DEFAULT;
 import static java.util.Collections.singleton;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class RuleTest {
+class RuleTest {
 
     private UserAgentFileParser myParser;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         myParser = new UserAgentFileParser(singleton(BROWSER));
     }
 
     @Test
-    public void testLiteralExpression() {
+    void testLiteralExpression() {
         final Rule rule = getRule("a");
 
         assertTrue(matches(rule, "a"));
@@ -31,7 +31,7 @@ public class RuleTest {
     }
 
     @Test
-    public void testLiteralQuestionMark() {
+    void testLiteralQuestionMark() {
         final Rule literal = getRule("?a");
 
         assertTrue(matches(literal, "aa"));
@@ -48,7 +48,7 @@ public class RuleTest {
     }
 
     @Test
-    public void testSuffix() {
+    void testSuffix() {
 
         final Rule expression = getRule("*abc*");
 
@@ -62,7 +62,7 @@ public class RuleTest {
     }
 
     @Test
-    public void testPrefix() {
+    void testPrefix() {
         final Rule expression = getRule("abc*");
 
         assertTrue(matches(expression, "abc"));
@@ -73,7 +73,7 @@ public class RuleTest {
     }
 
     @Test
-    public void testPostfix() {
+    void testPostfix() {
 
         final Rule expression = getRule("*abc");
 
@@ -85,7 +85,7 @@ public class RuleTest {
     }
 
     @Test
-    public void testPreFixMultiple() {
+    void testPreFixMultiple() {
 
         final Rule expression = getRule("a*z");
 
@@ -110,7 +110,7 @@ public class RuleTest {
     }
 
     @Test
-    public void testSuffixMultiple() {
+    void testSuffixMultiple() {
 
         final Rule rule = getRule("*a*z*");
 
@@ -125,7 +125,7 @@ public class RuleTest {
     }
 
     @Test
-    public void testRequires() {
+    void testRequires() {
         final Rule rule = getRule("*abc*def*");
         assertTrue(rule.requires("abc"));
         assertTrue(rule.requires("def"));

--- a/src/test/java/com/blueconic/browscap/impl/SearchableStringTest.java
+++ b/src/test/java/com/blueconic/browscap/impl/SearchableStringTest.java
@@ -1,20 +1,19 @@
 package com.blueconic.browscap.impl;
 
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.blueconic.browscap.impl.SearchableString.Cache;
+import org.junit.jupiter.api.Test;
 
-public class SearchableStringTest {
+class SearchableStringTest {
 
     @Test
-    public void testSearchableString() {
+    void testSearchableString() {
 
         final LiteralDomain domain = new LiteralDomain();
 
@@ -40,7 +39,7 @@ public class SearchableStringTest {
     }
 
     @Test
-    public void testGetIndices() {
+    void testGetIndices() {
         final LiteralDomain domain = new LiteralDomain();
 
         final Literal abc = domain.createLiteral("abc");
@@ -63,7 +62,7 @@ public class SearchableStringTest {
     }
 
     @Test
-    public void testCache() {
+    void testCache() {
         final Cache cache = new Cache();
 
         assertNull(cache.get(0));
@@ -76,7 +75,7 @@ public class SearchableStringTest {
     }
 
     @Test
-    public void testLiteralBasics() {
+    void testLiteralBasics() {
 
         final LiteralDomain domain = new LiteralDomain();
 
@@ -88,7 +87,7 @@ public class SearchableStringTest {
     }
 
     @Test
-    public void testLiteralMatches() {
+    void testLiteralMatches() {
 
         final LiteralDomain domain = new LiteralDomain();
 

--- a/src/test/java/com/blueconic/browscap/impl/UserAgentFileParserTest.java
+++ b/src/test/java/com/blueconic/browscap/impl/UserAgentFileParserTest.java
@@ -5,34 +5,31 @@ import static com.blueconic.browscap.impl.UserAgentFileParser.getParts;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
-
-import org.junit.Test;
+import static org.junit.jupiter.api.Assertions.*;
 
 import com.blueconic.browscap.Capabilities;
+import org.junit.jupiter.api.Test;
 
-public class UserAgentFileParserTest {
+class UserAgentFileParserTest {
 
     static final Capabilities DEFAULT = new UserAgentFileParser(singleton(BROWSER)).getDefaultCapabilities();
 
     @Test
-    public void testGetParts() {
+    void testGetParts() {
         assertEquals(asList("*", "a", "*"), getParts("*a*"));
         assertEquals(asList("*", "abc", "*"), getParts("*abc*"));
         assertEquals(asList("*"), getParts("*"));
         assertEquals(asList("a"), getParts("a"));
     }
 
-    @Test(expected = IllegalStateException.class)
-    public void testLiteralException() {
+    @Test
+    void testLiteralException() {
         final UserAgentFileParser parser = new UserAgentFileParser(singleton(BROWSER));
-        parser.createRule("", DEFAULT);
+        assertThrows(IllegalStateException.class, () -> parser.createRule("", DEFAULT));
     }
 
     @Test
-    public void testCreateRule() {
+    void testCreateRule() {
         final UserAgentFileParser parser = new UserAgentFileParser(singleton(BROWSER));
 
         final Rule exact = parser.createRule("a", DEFAULT);
@@ -81,7 +78,7 @@ public class UserAgentFileParserTest {
     }
 
     @Test
-    public void testGetValue() {
+    void testGetValue() {
 
         final UserAgentFileParser parser = new UserAgentFileParser(emptySet());
 

--- a/src/test/java/com/blueconic/browscap/impl/UserAgentParserTest.java
+++ b/src/test/java/com/blueconic/browscap/impl/UserAgentParserTest.java
@@ -12,29 +12,28 @@ import static com.blueconic.browscap.BrowsCapField.BROWSER;
 import static com.blueconic.browscap.impl.UserAgentFileParserTest.DEFAULT;
 import static com.blueconic.browscap.impl.UserAgentParserImpl.getOrderedRules;
 import static java.util.Collections.singleton;
-import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.BitSet;
 
-import org.junit.Before;
-import org.junit.Test;
-
 import com.blueconic.browscap.impl.UserAgentParserImpl.Filter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-public class UserAgentParserTest {
+class UserAgentParserTest {
 
     private UserAgentFileParser myParser;
 
-    @Before
-    public void setup() {
+    @BeforeEach
+    void setup() {
         myParser = new UserAgentFileParser(singleton(BROWSER));
     }
 
     @Test
-    public void testExcludes() {
+    void testExcludes() {
 
         final int length = 1017;
         final BitSet excludes = new BitSet(length);
@@ -65,7 +64,7 @@ public class UserAgentParserTest {
     }
 
     @Test
-    public void testGetIncludes() {
+    void testGetIncludes() {
         final Rule a = getRule("test*123*abc*");
         final Rule b = getRule("*test*abcd*");
         final Rule c = getRule("*123*test");
@@ -98,7 +97,7 @@ public class UserAgentParserTest {
     }
 
     @Test
-    public void testGetOrderedRules() {
+    void testGetOrderedRules() {
         final Rule a = getRule("a");
         final Rule b = getRule("b");
         final Rule aa = getRule("aa");

--- a/src/test/java/com/blueconic/browscap/impl/UserAgentServiceTest.java
+++ b/src/test/java/com/blueconic/browscap/impl/UserAgentServiceTest.java
@@ -11,7 +11,7 @@ import static com.blueconic.browscap.BrowsCapField.RENDERING_ENGINE_MAKER;
 import static com.blueconic.browscap.BrowsCapField.RENDERING_ENGINE_NAME;
 import static com.blueconic.browscap.BrowsCapField.RENDERING_ENGINE_VERSION;
 import static java.util.Arrays.asList;
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.BufferedReader;
 import java.io.FileInputStream;
@@ -22,18 +22,17 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
 
-import org.junit.Test;
-
 import com.blueconic.browscap.BrowsCapField;
 import com.blueconic.browscap.Capabilities;
 import com.blueconic.browscap.ParseException;
 import com.blueconic.browscap.UserAgentParser;
 import com.blueconic.browscap.UserAgentService;
+import org.junit.jupiter.api.Test;
 
-public class UserAgentServiceTest {
+class UserAgentServiceTest {
 
     @Test
-    public void testUserAgentsFromExternalFile() throws IOException, ParseException {
+    void testUserAgentsFromExternalFile() throws IOException, ParseException {
         final int ITERATIONS = 10;
 
         final Path path = Paths.get("src", "main", "resources", UserAgentService.getBundledCsvFileName());
@@ -49,7 +48,7 @@ public class UserAgentServiceTest {
     }
 
     @Test
-    public void testUserAgentsFromExternalInputStream() throws IOException, ParseException {
+    void testUserAgentsFromExternalInputStream() throws IOException, ParseException {
         final int ITERATIONS = 10;
 
         final Path path = Paths.get("src", "main", "resources", UserAgentService.getBundledCsvFileName());
@@ -66,7 +65,7 @@ public class UserAgentServiceTest {
     }
 
     @Test
-    public void testUserAgentsFromBundledFile() throws IOException, ParseException {
+    void testUserAgentsFromBundledFile() throws IOException, ParseException {
         final int ITERATIONS = 10;
 
         final UserAgentService uas = new UserAgentService();
@@ -110,7 +109,7 @@ public class UserAgentServiceTest {
     }
 
     @Test
-    public void testUserAgentsFromBundledFileWithCustomFields() throws IOException, ParseException {
+    void testUserAgentsFromBundledFileWithCustomFields() throws IOException, ParseException {
 
         final Collection<BrowsCapField> fields =
                 asList(BROWSER, BROWSER_TYPE, BROWSER_MAJOR_VERSION, DEVICE_TYPE, PLATFORM,


### PR DESCRIPTION
This PR migrates the tests to JUnit Jupiter.

This PR also updates to use Maven Surefire Plugin 2.22.2 as JUnit Jupiter requires it.